### PR TITLE
Fixing Build Issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,12 @@ project(DLib)
 option(BUILD_DUtils   "Build DUtils (basic c++ functions)." ON)
 option(BUILD_DUtilsCV "Build DUtilsCV (OpenCV functions, requires DUtils)." ON)
 option(BUILD_DVision  "Build DVision (computer vision functions, requires DUtilsCV)." ON)
+option(USE_CV_NONFREE "Use non-free parts of OpenCV (i.e. Surf)." ON)
+
+
+if(USE_CV_NONFREE)
+  add_definitions(-DCV_NONFREE)
+endif(USE_CV_NONFREE)
 
 if(BUILD_DUtils)
   set(HDRS include/DUtils/

--- a/include/DVision/DVision.h
+++ b/include/DVision/DVision.h
@@ -39,7 +39,9 @@ namespace DVision
 }
 
 // Features and descriptors
+#if CV_NONFREE //Surf is non-free and may not be available
 #include "SurfSet.h"
+#endif
 #include "BRIEF.h"
 
 // Image functions

--- a/include/DVision/Matches.h
+++ b/include/DVision/Matches.h
@@ -10,7 +10,7 @@
  
 #ifndef __D_MATCHES__
 #define __D_MATCHES__
-
+#if CV_NONFREE //Surf is non-free and may not be available
 #include <vector>
 #include <string>
 #include "SurfSet.h"
@@ -97,4 +97,5 @@ protected:
 
 }
 
+#endif
 #endif

--- a/include/DVision/SurfSet.h
+++ b/include/DVision/SurfSet.h
@@ -16,6 +16,7 @@
 
 #ifndef __D_SURF_SET__
 #define __D_SURF_SET__
+#if CV_NONFREE //Surf is non-free and may not be available
 
 // Set if U-SURF is supported by Opencv (probably by applying this patch:
 // https://code.ros.org/trac/opencv/ticket/825 )
@@ -316,4 +317,5 @@ std::vector<float> SurfSet::get(unsigned int i) const
 }
 
 #endif
+#endif //CV_NONFREE
 

--- a/src/DLib.cmake.in
+++ b/src/DLib.cmake.in
@@ -1,11 +1,12 @@
 FIND_LIBRARY(DLib_LIBRARY DLib
     PATHS @CMAKE_INSTALL_PREFIX@/lib
 )
-FIND_PATH(DLib_INCLUDE_DIR DLibConfig.cmake
-    PATHS @CMAKE_INSTALL_PREFIX@/include/@PROJECT_NAME@ 
-)
+
+SET(DLib_INCLUDE_DIR  "@CMAKE_INSTALL_PREFIX@/include")
+#For backward compatibility (i.e. use of "header.h" instead of "dir/header.h"
 LIST(APPEND DLib_INCLUDE_DIR ${DLib_INCLUDE_DIR}/../DUtils 
   ${DLib_INCLUDE_DIR}/../DUtilsCV ${DLib_INCLUDE_DIR}/../DVision)
+
 SET(DLib_LIBRARIES ${DLib_LIBRARY})
 SET(DLib_LIBS ${DLib_LIBRARY})
 SET(DLib_INCLUDE_DIRS ${DLib_INCLUDE_DIR})

--- a/src/DVision/Matches.cpp
+++ b/src/DVision/Matches.cpp
@@ -8,6 +8,7 @@
  *
  */
 
+#if CV_NONFREE //Surf is non-free and may not be available
 #include <iostream>
 #include <vector>
 #include <string>
@@ -112,4 +113,5 @@ void DVision::Matches::Load(const std::string &filename,
 
 // ---------------------------------------------------------------------------
 
+#endif //CV_NONFREE
 

--- a/src/DVision/SurfSet.cpp
+++ b/src/DVision/SurfSet.cpp
@@ -13,7 +13,7 @@
  * License: see the LICENSE.txt file
  *
  */
-
+#if CV_NONFREE //Surf is non-free and may not be available
 #include "SurfSet.h"
 #include <iostream>
 #include <fstream>
@@ -762,4 +762,4 @@ void SurfSet::Remove(const std::vector<unsigned int> &ids)
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 
-
+#endif //CV_NONFREE


### PR DESCRIPTION
I ran into some issues when trying out DLib + DBow2: If you install to a non-generic directory DBoW2 will not find the includes using the `#include "dir/header.h"` syntax. Also, using the standard opencv, I don't have Surf available, because it is non-free.
