### PR TITLE
Modernize OpenCV usage

### DIFF
--- a/include/DUtilsCV/Drawing.h
+++ b/include/DUtilsCV/Drawing.h
@@ -14,6 +14,7 @@
 #include <vector>
 #include <opencv2/core.hpp>
 #include <opencv2/imgproc.hpp>
+#include <opencv2/features2d.hpp>
 
 namespace DUtilsCV
 {

--- a/include/DUtilsCV/IO.h
+++ b/include/DUtilsCV/IO.h
@@ -14,6 +14,7 @@
 #include <iostream>
 #include <vector>
 #include <opencv2/core.hpp>
+#include <opencv2/features2d.hpp>
 #include <string>
 
 namespace DUtilsCV

--- a/include/DVision/BRIEF.h
+++ b/include/DVision/BRIEF.h
@@ -30,6 +30,7 @@
 #define __D_BRIEF__
 
 #include <opencv2/core.hpp>
+#include <opencv2/features2d.hpp>
 #include <vector>
 #include <boost/dynamic_bitset.hpp>
 

--- a/include/DVision/ImageFunctions.h
+++ b/include/DVision/ImageFunctions.h
@@ -12,6 +12,7 @@
 #define __D_IMAGE_FUNCTIONS__
 
 #include <opencv2/core.hpp>
+#include <opencv2/features2d.hpp>
 
 namespace DVision {
 

--- a/src/DVision/SurfSet.cpp
+++ b/src/DVision/SurfSet.cpp
@@ -24,7 +24,7 @@
 
 #include <opencv2/core.hpp>
 #include <opencv2/highgui.hpp>
-#include <opencv2/xfeatures2d/nonfree.hpp>
+#include <opencv2/nonfree/nonfree.hpp>
 
 
 using namespace std;
@@ -120,12 +120,12 @@ void SurfSet::_ExtractUpright(const cv::Mat &image, double hessianTh, bool exten
 
 void SurfSet::extract(const cv::Mat &image, const SURFParams &params)
 {
-  cv::Ptr<cv::xfeatures2d::SURF> surf = cv::xfeatures2d::SURF::create(
+  cv::SURF surf(
         params.hessianThreshold, params.nOctaves, params.nOctaveLayers,
         params.extended, params.upright);
 
   cv::Mat descs;
-  surf->detectAndCompute(image, cv::Mat() /* mask */, this->keys, descs);
+  surf(image, cv::Mat() /* mask */, this->keys, descs);
 
   const int L = (params.extended == 1 ? 128 : 64);
   this->descriptors.resize(this->keys.size() * L);
@@ -177,12 +177,12 @@ void SurfSet::compute(const cv::Mat &image,
   {
     this->keys = keypoints;
 
-    cv::Ptr<cv::xfeatures2d::SURF> surf = cv::xfeatures2d::SURF::create(
+    cv::SURF surf(
           params.hessianThreshold, params.nOctaves, params.nOctaveLayers,
           params.extended, params.upright);
 
     cv::Mat descs;
-    surf->compute(image, this->keys, descs);
+    surf.compute(image, this->keys, descs);
 
     this->descriptors.resize(this->keys.size() * descs.cols);
     this->laplacians.resize(this->keys.size());


### PR DESCRIPTION
Fixes mismatches in latest OpenCV,

- `cv::KeyPoint` now defined where needed through inclusion of `features2d.hpp`.
- `SurfSet.cpp` fixed to use new API of the SURF detector.