### PR TITLE
Add boost include directories if building DVision

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ if(BUILD_DVision)
 
   find_package(Boost QUIET)  # For dynamic_bitset
   if (Boost_FOUND)
+    include_directories(${Boost_INCLUDE_DIR})
     set(HDRS include/DVision/BRIEF.h ${HDRS})
     set(SRCS src/DVision/BRIEF.cpp ${SRCS})
   endif(Boost_FOUND)


### PR DESCRIPTION
Need to include the boost directories, else the required headers are not found.