### PR TITLE
OpenCV4 support (partial)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,8 +43,8 @@ if(BUILD_DUtilsCV)
     include/DUtilsCV/DUtilsCV.h        include/DUtilsCV/GUI.h             include/DUtilsCV/IO.h              include/DUtilsCV/Transformations.h
     ${HRDS})
   set(SRCS 
-    src/DUtilsCV/Drawing.cpp         src/DUtilsCV/Geometry.cpp        src/DUtilsCV/Mat.cpp             src/DUtilsCV/Types.cpp
-    src/DUtilsCV/GUI.cpp             src/DUtilsCV/IO.cpp              src/DUtilsCV/Transformations.cpp
+    src/DUtilsCV/Geometry.cpp        src/DUtilsCV/Mat.cpp             src/DUtilsCV/Types.cpp
+    src/DUtilsCV/IO.cpp              src/DUtilsCV/Transformations.cpp
     ${SRCS})
 endif(BUILD_DUtilsCV)
 

--- a/src/DUtilsCV/Drawing.cpp
+++ b/src/DUtilsCV/Drawing.cpp
@@ -23,11 +23,11 @@ void Drawing::drawKeyPoints(cv::Mat &image,
     const std::vector<cv::KeyPoint> &keypoints,
     bool colorOctave, bool useCartesianAngle)
 {
-  CvScalar colors[4] = {
-    cvScalar(0, 0, 255),
-    cvScalar(0, 255, 0),
-    cvScalar(255, 0, 0),
-    cvScalar(255, 255, 255) 
+  cv::Scalar colors[4] = {
+    cv::Scalar(0, 0, 255),
+    cv::Scalar(0, 255, 0),
+    cv::Scalar(255, 0, 0),
+    cv::Scalar(255, 255, 255) 
   };
 
   const double PI = 3.14159265;
@@ -39,7 +39,7 @@ void Drawing::drawKeyPoints(cv::Mat &image,
     float s = it->size / 2.f;
     //if(s < 3.f) s = 3.f;
     
-    const CvScalar *color;
+    const cv::Scalar *color;
     if(!colorOctave || it->octave < 1 || it->octave > 3)
       color = &colors[3];
     else
@@ -48,7 +48,7 @@ void Drawing::drawKeyPoints(cv::Mat &image,
     int r1 = (int)(it->pt.y + 0.5);
     int c1 = (int)(it->pt.x + 0.5);
     
-    cv::circle(image, cvPoint(c1, r1), (int)s, *color, 1);
+    cv::circle(image, cv::Point(c1, r1), (int)s, *color, 1);
     
     if(it->angle >= 0)
     {
@@ -62,7 +62,7 @@ void Drawing::drawKeyPoints(cv::Mat &image,
       else
         r2 = (int)(s * sin(o) + it->pt.y + 0.5);
 
-      cv::line(image, cvPoint(c1, r1), cvPoint(c2, r2), *color);
+      cv::line(image, cv::Point(c1, r1), cv::Point(c2, r2), *color);
     }
   }
 }
@@ -102,12 +102,12 @@ void Drawing::drawCorrespondences(cv::Mat &image, const cv::Mat &img1,
   
   cv::Mat aux1, aux2;
   if(img1.channels() > 1)
-    cv::cvtColor(img1, aux1, CV_RGB2GRAY);
+    cv::cvtColor(img1, aux1, cv::COLOR_RGB2GRAY);
   else
     aux1 = img1.clone();
   
   if(img2.channels() > 1)
-    cv::cvtColor(img2, aux2, CV_RGB2GRAY);
+    cv::cvtColor(img2, aux2, cv::COLOR_RGB2GRAY);
   else
     aux2 = img2.clone();
 
@@ -118,7 +118,7 @@ void Drawing::drawCorrespondences(cv::Mat &image, const cv::Mat &img1,
   IplImage ipl_im = IplImage(im);
   IplImage* ipl_ret = &ipl_im;
 
-  CvRect roi;
+  cv::Rect roi;
   roi.x = 0;
   roi.y = 0;
   roi.width = img1.cols;
@@ -140,7 +140,7 @@ void Drawing::drawCorrespondences(cv::Mat &image, const cv::Mat &img1,
 	cvResetImageROI(ipl_ret);
 
 	// draw correspondences
-	cv::cvtColor(im, image, CV_GRAY2RGB);
+	cv::cvtColor(im, image, cv::COLOR_GRAY2RGB);
 	
 	for(unsigned int i = 0; i < c1.size(); ++i)
 	{
@@ -151,12 +151,12 @@ void Drawing::drawCorrespondences(cv::Mat &image, const cv::Mat &img1,
 	  
 	  py += img1.rows;
 	  
-    CvScalar color = cvScalar( 
+    cv::Scalar color = cv::Scalar( 
       int(((double)rand()/((double)RAND_MAX + 1.0)) * 256.0),
       int(((double)rand()/((double)RAND_MAX + 1.0)) * 256.0),
       int(((double)rand()/((double)RAND_MAX + 1.0)) * 256.0));
 
-    cv::line(image, cvPoint(mx, my), cvPoint(px, py), color, 1);
+    cv::line(image, cv::Point(mx, my), cv::Point(px, py), color, 1);
 	}
 }
 
@@ -206,19 +206,19 @@ void Drawing::drawReferenceSystem(cv::Mat &image, const cv::Mat &cRo,
   cv::projectPoints(cv::Mat(oP), cRo, cto, A, k, points2d);
   
   // draw axis
-  CvScalar bluez, greeny, redx;
+  cv::Scalar bluez, greeny, redx;
   
   if(image.channels() == 3 )
   {
-    bluez = cvScalar(255,0,0);
-    greeny = cvScalar(0,255,0);
-    redx = cvScalar(0,0,255);
+    bluez = cv::Scalar(255,0,0);
+    greeny = cv::Scalar(0,255,0);
+    redx = cv::Scalar(0,0,255);
   }
   else
   {
-    bluez = cvScalar(18,18,18);
-    greeny = cvScalar(182,182,182);
-    redx = cvScalar(120,120,120);
+    bluez = cv::Scalar(18,18,18);
+    greeny = cv::Scalar(182,182,182);
+    redx = cv::Scalar(120,120,120);
   }
 
   cv::line(image, points2d[0], points2d[1], redx, 2);

--- a/src/DVision/BRIEF.cpp
+++ b/src/DVision/BRIEF.cpp
@@ -52,7 +52,7 @@ void BRIEF::compute(const cv::Mat &image,
     cv::Mat aux;
     if(image.depth() == 3)
     {
-      cv::cvtColor(image, aux, CV_RGB2GRAY);
+      cv::cvtColor(image, aux, cv::COLOR_RGB2GRAY);
     }
     else
     {

--- a/src/DVision/FSolver.cpp
+++ b/src/DVision/FSolver.cpp
@@ -146,7 +146,7 @@ cv::Mat FSolver::findFundamentalMat(const cv::Mat &P1, const cv::Mat &P2,
       cv::Mat sq_ab, norms;
       cv::multiply(l1.rowRange(0,2), l1.rowRange(0,2), sq_ab);
       
-      cv::reduce(sq_ab, norms, 0, CV_REDUCE_SUM); // 0 = single row
+      cv::reduce(sq_ab, norms, 0, cv::REDUCE_SUM); // 0 = single row
       cv::sqrt(norms, norms); // norms is Nx2
       
       cv::Mat thresholds = norms * reprojection_error; // Nx1
@@ -157,7 +157,7 @@ cv::Mat FSolver::findFundamentalMat(const cv::Mat &P1, const cv::Mat &P2,
       // d(x, l) = dot(x*, l*), * means normalized
       cv::Mat prod, dot;
       cv::multiply(l1, Q1, prod); // l1 against Q1 (homogeneous in image coords)
-      cv::reduce(prod, dot, 0, CV_REDUCE_SUM); // dot is Nx1
+      cv::reduce(prod, dot, 0, cv::REDUCE_SUM); // dot is Nx1
       
       // error w/o sign
       dot = abs(dot);

--- a/src/DVision/HSolver.cpp
+++ b/src/DVision/HSolver.cpp
@@ -141,7 +141,7 @@ cv::Mat HSolver::findHomography(const cv::Mat &P1, const cv::Mat &P2,
       cv::multiply(ab, ab, sq_ab);
       
       cv::Mat error;
-      cv::reduce(sq_ab, error, 0, CV_REDUCE_SUM); // 0 = single row
+      cv::reduce(sq_ab, error, 0, cv::REDUCE_SUM); // 0 = single row
       // squared error is positive
     
       // get inliers


### PR DESCRIPTION
Addresses #21 but removes GUI stuff as a workaround. 

 * change `CV_RGB2GRAY` -> `cv::COLOR_RGB2GRAY` etc. to support OpenCV 4
 * workaround to just build DBoW2 as a library: drop GUI.cpp and Drawing.cpp from the build. These were not as easy to modify to support OpenCV 4 as they ise IplImage, which has been deprecated and AFAIK cannot be fixed with search & replace